### PR TITLE
Add API Endpoint for Candidate Registration with Validation and Email Verification

### DIFF
--- a/app/Http/Controllers/Api/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/Auth/RegisterController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Api\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\User; // Or App\User if using older structure
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Auth\Events\Registered;
+use App\Events\UserRegistered;
+use Jrean\UserVerification\Facades\UserVerification;
+use App\Http\Requests\Front\UserFrontRegisterFormRequest;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Database\QueryException;
+
+class RegisterController extends Controller
+{
+    
+
+    public function register(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'first_name' => 'required|max:80',
+            'last_name' => 'required|max:80',
+            'email' => 'required|unique:users,email|email|max:100',
+            'mobile_num' => 'required',
+            'password' => 'required|confirmed|min:6|max:50',
+            'terms_of_use' => 'required',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+    
+        log::info("entry");
+        try {
+            Log::channel('api')->info("Attempting registration", $request->except('password'));
+
+            $user = new User();
+            $user->first_name = $request->input('first_name');
+            // $user->middle_name = $request->input('middle_name');
+            $user->last_name = $request->input('last_name');
+            $user->email = $request->input('email');
+            $user->mobile_num = $request->input('mobile_num');
+            $user->password = bcrypt($request->input('password'));
+            $user->is_active = 0;
+            $user->verified = 0;
+
+            if (!$user->save()) {
+                throw new \Exception('Failed to save user');
+            }
+
+            $user->name = $user->getName();
+            if (!$user->update()) {
+                throw new \Exception('Failed to update user name');
+            }
+
+            event(new Registered($user));
+            event(new UserRegistered($user));
+
+            $this->guard()->login($user);
+
+            UserVerification::generate($user);
+            UserVerification::send(
+                $user,
+                'User Verification',
+                config('mail.recieve_to.address'),
+                config('mail.recieve_to.name')
+            );
+
+            return response()->json([
+                'message' => 'User registered and logged in successfully. Verification email sent.',
+                'user' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                ],
+            ], 201);
+        } catch (QueryException $e) {
+            Log::channel('api')->error('Registration failed', ['error' => $e->getMessage()]);
+            return response()->json([
+                'message' => 'Registration failed: Email already exists or data conflict.',
+                'error' => $e->getMessage(),
+            ], 409);
+        } catch (\Exception $e) {
+            Log::channel('api')->error('Registration failed', ['error' => $e->getMessage()]);
+            return response()->json([
+                'message' => 'Registration failed: Unexpected error occurred.',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+}

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -13,6 +13,7 @@ use Jrean\UserVerification\Facades\UserVerification;
 use App\Http\Requests\Front\UserFrontRegisterFormRequest;
 use Illuminate\Auth\Events\Registered;
 use App\Events\UserRegistered;
+use Illuminate\Support\Facades\Log;
 
 class RegisterController extends Controller
 {
@@ -49,6 +50,7 @@ use RegistersUsers;
 
     public function register(UserFrontRegisterFormRequest $request)
     {
+        
         $user = new User();
         $user->first_name = $request->input('first_name');
         // $user->middle_name = $request->input('middle_name');

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -42,6 +42,7 @@ class Kernel extends HttpKernel
         'api' => [
             'throttle:60,1',
             'bindings',
+            \App\Http\Middleware\LogApiRequests::class,
         ],
     ];
 

--- a/app/Http/Middleware/LogApiRequests.php
+++ b/app/Http/Middleware/LogApiRequests.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Log;
+
+class LogApiRequests
+{
+    public function handle($request, Closure $next)
+    {
+        Log::channel('api')->info('API Request', [
+            'method' => $request->method(),
+            'url' => $request->fullUrl(),
+            'ip' => $request->ip(),
+            'input' => $request->except(['password', 'password_confirmation']),
+            'timestamp' => now()->toDateTimeString(),
+        ]);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/Front/UserFrontRegisterFormRequest.php
+++ b/app/Http/Requests/Front/UserFrontRegisterFormRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Front;
 
 use Auth;
 use App\Http\Requests\Request;
+use Illuminate\Support\Facades\Log;
 
 class UserFrontRegisterFormRequest extends Request
 {
@@ -25,7 +26,10 @@ class UserFrontRegisterFormRequest extends Request
      */
     public function rules()
     {
-
+        Log::info('UserFrontRegisterFormRequest');
+        Log::info('all: ' . json_encode($this->all()));
+        
+        
         return [
             'first_name' => 'required|max:80',
             'middle_name' => 'max:80',

--- a/config/logging.php
+++ b/config/logging.php
@@ -63,5 +63,10 @@ return [
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
         ],
+        'api' => [
+        'driver' => 'single',
+        'path' => storage_path('logs/api.log'),
+        'level' => 'debug',
+        ],
     ],
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,10 @@
 <?php
 
+
+use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
+use App\Http\Controllers\Api\Auth\RegisterController;
+
 
 /*
   |--------------------------------------------------------------------------
@@ -13,7 +17,9 @@ use Illuminate\Http\Request;
   |
  */
  
- 
+Route::prefix('auth')->group(function () {
+    Route::post('/register', [RegisterController::class, 'register']);
+});
 Route::get('/sample', function () {
     return response()->json([
         'message' => 'Hello from Laravel API!',


### PR DESCRIPTION
This pull request adds a dedicated API endpoint to handle candidate registration. It includes:

🔧 Features:

- Validates candidate details:
  - First Name, Last Name (max 80 chars)
  - Unique and valid Email
  - Mobile Number
  - Password with confirmation (min 6 chars)
  - Terms of Use agreement

- Creates a new user (candidate) record with:
  - Password encryption (bcrypt)
  - Default inactive and unverified status

- Automatically sets full name via getName()
- Sends verification email using Jrean\UserVerification
- Logs registration activity to the custom api log channel
- Fires standard Laravel Registered event and a custom UserRegistered event

- Handles:
  - Validation errors (422)
  - Duplicate entries/conflicts (409)
  - Unexpected server errors (500)

📝 Remaining (to be done in future PRs):

- Candidate login endpoint
- Candidate logout endpoint

📌 This PR is linked to issue #2 